### PR TITLE
Fixed pattern error on gold_block recipe example

### DIFF
--- a/java/recipes.md
+++ b/java/recipes.md
@@ -429,9 +429,9 @@ The following sets two placeholders in the pattern, being "#" and "^", while the
 {
     "type": "crafting_shaped",
     "pattern": [
-        "##",
+        "###",
         "^^^",
-        "##"
+        "###"
     ],
     "key": {
         "#": {


### PR DESCRIPTION
Hi there. 

Fixed pattern error in iron to gold shaped recipe. Unmatched row lengths between 2nd row vs 1st and 3rd row.

This guide is awesome, by the way!